### PR TITLE
Fix installing and importing iree-turbine

### DIFF
--- a/apps/shark_studio/modules/ckpt_processing.py
+++ b/apps/shark_studio/modules/ckpt_processing.py
@@ -4,7 +4,7 @@ import re
 import requests
 import torch
 import safetensors
-from shark_turbine.aot.params import (
+from iree.turbine.aot.params import (
     ParameterArchiveBuilder,
 )
 from io import BytesIO

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ wheel
 
 
 torch==2.3.0
-shark-turbine @ git+https://github.com/iree-org/iree-turbine.git@main
+iree-turbine @ git+https://github.com/iree-org/iree-turbine.git@main
 turbine-models @ git+https://github.com/nod-ai/SHARK-ModelDev.git@main#subdirectory=models
 diffusers @ git+https://github.com/nod-ai/diffusers@0.29.0.dev0-shark
 brevitas @ git+https://github.com/Xilinx/brevitas.git@6695e8df7f6a2c7715b9ed69c4b78157376bb60b


### PR DESCRIPTION
The package was renamed from `shark-turbine` to `iree.turbine` with iree-org/iree-turbine@40016ad.